### PR TITLE
🐛 removes audioSession category options

### DIFF
--- a/Sources/SwiftRadioPlayer/SwiftRadioPlayer.swift
+++ b/Sources/SwiftRadioPlayer/SwiftRadioPlayer.swift
@@ -239,18 +239,9 @@ open class SwiftRadioPlayer: NSObject {
         super.init()
 
         #if !os(macOS)
-        let options: AVAudioSession.CategoryOptions
-
-        // Enable bluetooth playback
-        #if os(iOS)
-        options = [.defaultToSpeaker, .allowBluetooth, .allowAirPlay]
-        #else
-        options = []
-        #endif
-
         // Start audio session
         let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode.default, options: options)
+        try? audioSession.setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode.default)
         #endif
 
         // Notifications


### PR DESCRIPTION
Per [Apple Developer documentation](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions-swift.struct)

`defaultToSpeaker`: « You can set this option only when using the playAndRecord category. »
`.allowBluetooth`: « You can set this option only if the audio session category is playAndRecord or record. »
`.allowAirplay`: « You can only explicitly set this option if the audio session’s category is set to playAndRecord. For most other audio session categories, the system sets this option implicitly. »

fixes #3 